### PR TITLE
no need to alias shared pointer. Removed ampersand.

### DIFF
--- a/chrono_utils/ChUtilsCreators.cpp
+++ b/chrono_utils/ChUtilsCreators.cpp
@@ -592,7 +592,7 @@ void LoadConvexMesh(const std::string& file_name,
 
 // -----------------------------------------------------------------------------
 
-void AddConvexCollisionModel(ChSharedPtr<ChBody>& body,
+void AddConvexCollisionModel(ChSharedPtr<ChBody> body,
                              ChTriangleMeshConnected& convex_mesh,
                              ChConvexDecompositionHACDv2& convex_shape,
                              const ChVector<>& pos,

--- a/chrono_utils/ChUtilsCreators.h
+++ b/chrono_utils/ChUtilsCreators.h
@@ -234,7 +234,7 @@ void LoadConvexMesh(const std::string& file_name,
 // use_original_asset can be used to specify if the mesh or the convex decomp
 // should be used for visualization
 CH_UTILS_API
-void AddConvexCollisionModel(ChSharedPtr<ChBody>& body,
+void AddConvexCollisionModel(ChSharedPtr<ChBody> body,
                              geometry::ChTriangleMeshConnected& convex_mesh,
                              collision::ChConvexDecompositionHACDv2& convex_shape,
                              const ChVector<>& pos = ChVector<>(0, 0, 0),


### PR DESCRIPTION
No need to alias shared pointer. Besides, aliasing causes error when sending a derived class.